### PR TITLE
Resolved Copy and Export functionality for the MultipleChoiceAssessment within the Tool History Drawer Component

### DIFF
--- a/frontend/utils/ToolHistoryUtils.js
+++ b/frontend/utils/ToolHistoryUtils.js
@@ -5,7 +5,7 @@ export const exportToCSV = (data, panelData) => {
   let headers;
   let rows;
 
-  if (data?.toolId === '0') {
+  if (data?.tool_id === '0') {
     headers = [
       'Question',
       'Option A',
@@ -48,16 +48,18 @@ export const exportToCSV = (data, panelData) => {
 
 export const copyToClipboard = (data, panelData) => {
   const label =
-    data?.toolId === '0' ? 'Questions and Options' : 'Concepts and Definitions';
+    data?.tool_id === '0'
+      ? 'Questions and Options'
+      : 'Concepts and Definitions';
   const textToCopy = `
     Title: ${data?.title || 'Default Title'}
-    
+
     Content: ${data?.content || 'Default Content'}
-    
+
     ${label}:
     ${panelData
       .map((item, i) =>
-        data?.toolId === '0'
+        data?.tool_id === '0'
           ? `${i + 1}. ${item.question}\n${item.choices
               ?.map((choice) => `   ${choice.key}. ${choice.value}`)
               .join('\n')}`


### PR DESCRIPTION
# Description
The copy/export to csv functionality buttons within the tool history drawer component worked for flash cards, but only rendered undefined values. I solved this issue by fixing the syntax error of accessing the tool_id within the toolHistory data state in the ToolHistoryUtils.js file

Ticket: N/A

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
