### PR TITLE
Resolved ToolHistory Card Skeleton Loader not Working as Intended

### DIFF
--- a/frontend/components/ToolHistoryListingContainer/ToolHistoryListingContainer.jsx
+++ b/frontend/components/ToolHistoryListingContainer/ToolHistoryListingContainer.jsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 
 import { Grid, Typography } from '@mui/material';
 
+import { useSelector } from 'react-redux';
+
 import { ToolCardSkeleton } from '../ToolCard';
 import ToolHistoryCard from '../ToolHistoryCard';
 
@@ -23,7 +25,9 @@ const DEFAULT_HISTORY = new Array(4)
  * @returns {JSX.Element} The rendered ToolHistoryListingContainer component.
  */
 const ToolHistoryListingContainer = (props) => {
-  const { data, loading, category } = props;
+  const { data, category } = props;
+
+  const { loading } = useSelector((state) => state.toolHistory);
 
   const [openDrawer, setOpenDrawer] = useState(false);
   const [selectedCardData, setSelectedCardData] = useState(null);


### PR DESCRIPTION
# Description
The `ToolHistoryListingContainer.jsx `component wasn't accessing the loading state from the `toolHistorySlices.js` due to prop drilling. Issue has been resolved by using a useSelector to directly access the loading state within the component.

Ticket: N/A

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
