### PR TITLE
Update index.jsx

### DIFF
--- a/components/FileTypeSelectorInput/index.jsx
+++ b/components/FileTypeSelectorInput/index.jsx
@@ -1,9 +1,8 @@
 import { Help } from '@mui/icons-material';
-import { Grid, Tooltip, Typography } from '@mui/material';
+import { Grid, Tooltip, Typography, Button } from '@mui/material';
 import { useWatch } from 'react-hook-form-mui';
 
 import PrimaryFileUpload from '@/components/PrimaryFileUpload';
-import PrimarySelectorInput from '@/components/PrimarySelectorInput';
 import PrimaryTextFieldInput from '@/components/PrimaryTextFieldInput';
 
 import styles from './styles';
@@ -17,10 +16,9 @@ const FileTypeSelectorInput = ({
   helperText,
   setValue,
   getValues,
-  ref,
   control,
 }) => {
-  const selectedFileType = useWatch({ control });
+  const selectedFileType = useWatch({ control, name });
 
   const renderLabel = (text) => (
     <Grid {...styles.labelGridProps}>
@@ -33,6 +31,41 @@ const FileTypeSelectorInput = ({
     </Grid>
   );
 
+  const renderFileTypeSelector = () => {
+    const halfLength = Math.ceil(fileTypes.length / 2);
+    const leftColumn = fileTypes.slice(0, halfLength);
+    const rightColumn = fileTypes.slice(halfLength);
+
+    return (
+      <div style={styles.gridContainer}>
+        <div>
+          {leftColumn.map((type) => (
+            <Button
+              key={type.key}
+              onClick={() => setValue(name, type.key)}
+              className={selectedFileType === type.key ? 'selected' : ''}
+              sx={styles.fileTypeButton}
+            >
+              {type.label}
+            </Button>
+          ))}
+        </div>
+        <div>
+          {rightColumn.map((type) => (
+            <Button
+              key={type.key}
+              onClick={() => setValue(name, type.key)}
+              className={selectedFileType === type.key ? 'selected' : ''}
+              sx={styles.fileTypeButton}
+            >
+              {type.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
   const renderInputField = () => {
     const urlOnlyTypes = [
       'GOOGLE_DOCS',
@@ -43,7 +76,7 @@ const FileTypeSelectorInput = ({
       'youtube_url',
     ];
 
-    if (urlOnlyTypes.includes(selectedFileType[name])) {
+    if (urlOnlyTypes.includes(selectedFileType)) {
       return (
         <Grid item {...styles.inputGridProps}>
           <PrimaryTextFieldInput
@@ -59,59 +92,33 @@ const FileTypeSelectorInput = ({
       );
     }
     return (
-      <>
-        {/* <Grid item {...styles.inputGridProps}>
-            <PrimaryTextFieldInput
-              name={`${name}_url`}
-              id={`${name}_url`}
-              title={renderLabel("URL")}
-              placeholder="Enter URL e.g http://..."
-              control={control}
-              error={error}
-              helperText={helperText}
-            />
-          </Grid>
-          <Grid container justifyContent="center" alignItems="center" sx={{ my: 0, mb: 0 }}>
-            <Typography variant="body2" color="textSecondary">
-              OR
-            </Typography>
-          </Grid> */}
-        <Grid item {...styles.inputGridProps} sx={{ marginTop: '-30px' }}>
-          <PrimaryFileUpload
-            name={`${name}_file`}
-            id={`${name}_file`}
-            title={renderLabel('Upload File')}
-            control={control}
-            setValue={setValue}
-            error={error}
-            helperText={helperText}
-            multiple
-            placeholder="Choose Files to Upload"
-            showChips
-            showCheckbox
-            displayEmpty
-            ref={ref}
-            getValues={() => getValues()}
-            color="purple"
-            bgColor="#23252A"
-          />
-        </Grid>
-      </>
+      <Grid item {...styles.inputGridProps} sx={{ marginTop: '-30px' }}>
+        <PrimaryFileUpload
+          name={`${name}_file`}
+          id={`${name}_file`}
+          title={renderLabel('Upload File')}
+          control={control}
+          setValue={setValue}
+          error={error}
+          helperText={helperText}
+          multiple
+          placeholder="Choose Files to Upload"
+          showChips
+          showCheckbox
+          displayEmpty
+          getValues={() => getValues()}
+          color="purple"
+          bgColor="#23252A"
+        />
+      </Grid>
     );
   };
 
   return (
     <Grid container direction="column" spacing={2}>
       <Grid item {...styles.inputGridProps}>
-        <PrimarySelectorInput
-          name={`${name}`}
-          label={renderLabel(`Select ${label} Type`)}
-          control={control}
-          menuList={fileTypes.map((type) => ({
-            id: type.key,
-            label: type.label,
-          }))}
-        />
+        {renderLabel(`Select ${label} Type`)}
+        {renderFileTypeSelector()}
       </Grid>
       {renderInputField()}
     </Grid>
@@ -119,3 +126,4 @@ const FileTypeSelectorInput = ({
 };
 
 export default FileTypeSelectorInput;
+


### PR DESCRIPTION
## Description

FileTypeSelectorInput component to display the options in a two-column grid layout instead of a dropdown menu. In this way you can see the totality of options at once.  

## Type of Change

Please select the type(s) of change that apply and delete those that do not. 

- [ ] **Other**: FileTypeSelectorInput component to display the options in a two-column grid layout instead of a dropdown menu

## Proposed Solution

I used the AI Assistant from Replit. 

Here is the prompt that I wrote:
FileTypeSelectorInput component to display the options in a two-column grid layout instead of a dropdown menu.
Create them side by side slipped into one half on the left side and the other half of options on the right side.
Here is how it should looks like:
PDF         XLS
CSV         XML
TXT         GOOGLE_DOCS
MD         GOOGLE_SHEETS
URL         GOOGLE_SLIDES
PPTX       GOOGLE_DRIVE
DOCX     IMAGES

 