### PR TITLE
Update styles.js

### DIFF
--- a/components/FileTypeSelectorInput/styles.js
+++ b/components/FileTypeSelectorInput/styles.js
@@ -19,6 +19,30 @@ const styles = {
     justifyContent: 'flex-start',
     alignItems: 'center',
   },
+  fileTypeButton: {
+    my: 0.5,
+    textTransform: 'none',
+    height: '48px',
+    borderRadius: '8px',
+    width: '100%',
+    backgroundColor: '#23252A',
+    color: 'white',
+    '&:hover': {
+      backgroundColor: '#2F3136',
+    },
+    '&.selected': {
+      backgroundColor: '#4A4D55',
+    }
+  },
+  gridContainer: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(2, 1fr)',
+    gap: '8px',
+    width: '100%',
+    padding: '16px',
+    backgroundColor: '#1E1E1E',
+    borderRadius: '8px',
+  }
 };
 
 export default styles;


### PR DESCRIPTION
## Description

FileTypeSelectorInput component to display the options in a two-column grid layout instead of a dropdown menu. In this way you can see the totality of options at once.  

## Type of Change

Please select the type(s) of change that apply and delete those that do not. 

- [ ] **Other**: FileTypeSelectorInput component to display the options in a two-column grid layout instead of a dropdown menu

## Proposed Solution

I used the AI Assistant from Replit. 

Here is the prompt that I wrote:
FileTypeSelectorInput component to display the options in a two-column grid layout instead of a dropdown menu.
Create them side by side slipped into one half on the left side and the other half of options on the right side.
Here is how it should looks like:
PDF         XLS
CSV         XML
TXT         GOOGLE_DOCS
MD         GOOGLE_SHEETS
URL         GOOGLE_SLIDES
PPTX       GOOGLE_DRIVE
DOCX     IMAGES

