### PR TITLE
Fix two typos in renderPasswordInput function

### DIFF
--- a/templates/SignIn/SignInForm/SignInForm.jsx
+++ b/templates/SignIn/SignInForm/SignInForm.jsx
@@ -126,7 +126,7 @@ const SignInForm = (props) => {
     );
   };
 
-  const renderPaswordInput = () => {
+  const renderPasswordInput = () => { // Corrected function name
     return (
       <Grid {...styles.passwordGridProps}>
         <Grid {...styles.passwordInputGridProps}>
@@ -168,7 +168,7 @@ const SignInForm = (props) => {
     >
       <Grid {...sharedStyles.formGridProps}>
         {renderEmailInput()}
-        {renderPaswordInput()}
+        {renderPasswordInput()} {/* Corrected function call */}
         {renderSubmitButton()}
       </Grid>
     </FormContainer>


### PR DESCRIPTION
## Description

Fixed two typos in the `renderPasswordInput` function where "Password" was incorrectly spelled as "Pasword" (missing the second 's').

**Lines affected:**
- Line 129: `const renderPaswordInput` → `const renderPasswordInput`
- Line 171: `{renderPaswordInput()}` → `{renderPasswordInput()}`

## Type of Change

- [x] Documentation/Code quality improvement (typo fix)
- [x] Non-breaking change

## Motivation

Correcting these typos improves code readability and maintains consistency with proper English spelling throughout the codebase. While these misspellings don't affect functionality (since the function name and call matched), they could cause confusion for developers reading or maintaining the code.

## Changes Made

1. Corrected function declaration name from `renderPaswordInput` to `renderPasswordInput` (line 129)
2. Updated function call to match the corrected spelling (line 171)